### PR TITLE
Fix build for Windows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
         fi
 
     - name: Build
-      run: go build -v ./...
+      run: ./build-binary.sh
 
     - name: Vet
       run: go vet -v ./...

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ mkdir -p out && go test -coverprofile=out/coverage.out ./... && go tool cover -h
 To build the **metrics-viewer** into a Docker image and use it
 ```shell
 # Build the Docker image
-docker build -t metrics-viewer:0.2.0 .
+docker build -t metrics-viewer:0.2.1 .
 
 # Test the Docker image
-docker run --rm metrics-viewer:0.2.0 --version
+docker run --rm metrics-viewer:0.2.1 --version
 ```
 
 ## Installation of local binary with JFrog CLI

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,6 @@
+## 0.2.1 (Sep 29, 2021)
+- Fix build for Windows
+
 ## 0.2.0 (Sep 23, 2021)
 - Update JFrog CLI dependencies
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/eldada/metrics-viewer
 
-go 1.14
+go 1.16
 
 require (
 	github.com/andybalholm/brotli v1.0.3 // indirect
-	github.com/buger/goterm v1.0.3
+	github.com/buger/goterm v1.0.1
 	github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1
 	github.com/hpcloud/tail v1.0.1-0.20180514194441-a1dbeea552b7
 	github.com/jfrog/jfrog-cli-core/v2 v2.3.0
@@ -16,5 +16,3 @@ require (
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
-
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
-github.com/buger/goterm v1.0.3 h1:7V/HeAQHrzPk/U4BvyH2g9u+xbUW9nr4yRPyG59W4fM=
-github.com/buger/goterm v1.0.3/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
+github.com/buger/goterm v1.0.1 h1:kSgw3jcjYUzC0Uh/eG8ULjccuz353solup27lUH8Zug=
+github.com/buger/goterm v1.0.1/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
 github.com/buger/jsonparser v0.0.0-20180910192245-6acdf747ae99/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ func getApp() components.App {
 	app := components.App{}
 	app.Name = "metrics-viewer"
 	app.Description = "Easily present Open Metrics data in terminal."
-	app.Version = "v0.2.0"
+	app.Version = "v0.2.1"
 	app.Commands = getCommands()
 	return app
 }


### PR DESCRIPTION
Build for Windows fails due to an issue in `buger/goterm@v1.0.3` (see https://github.com/buger/goterm/issues/39).
Downgrading to `v1.0.1` to fix it.